### PR TITLE
:sparkles: Enhance insertIgnore method to support SQLite driver

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -6,6 +6,7 @@ namespace Lsr\Db;
 use DateTimeInterface;
 use Dibi\Connection as DibiConnection;
 use Dibi\DriverException;
+use Dibi\Drivers\SqliteDriver;
 use Dibi\Exception;
 use Dibi\Result;
 use JetBrains\PhpStorm\Language;
@@ -254,7 +255,14 @@ final class Connection
      * @throws Exception
      */
     public function insertIgnore(string $table, iterable $args) : int {
-        $result = $this->connection->insert($table, $args)->setFlag('IGNORE')->execute(\Dibi\Fluent::AffectedRows);
+        $query = $this->connection->insert($table, $args);
+        if ($this->connection->getDriver() instanceof SQliteDriver) {
+            $query->setFlag('OR IGNORE');
+        }
+        else {
+            $query->setFlag('IGNORE');
+        }
+        $result = $query->execute(\Dibi\Fluent::AffectedRows);
         assert(is_int($result));
         return $result;
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -256,7 +256,7 @@ final class Connection
      */
     public function insertIgnore(string $table, iterable $args) : int {
         $query = $this->connection->insert($table, $args);
-        if ($this->connection->getDriver() instanceof SQliteDriver) {
+        if ($this->connection->getDriver() instanceof SqliteDriver) {
             $query->setFlag('OR IGNORE');
         }
         else {


### PR DESCRIPTION
This pull request introduces support for SQLite-specific behavior in the `insertIgnore` method of the `Connection` class. It also includes a minor import addition to support this functionality.

### SQLite-specific behavior:

* [`src/Connection.php`](diffhunk://#diff-fdb82797ac69303b7f9b33a9695e1eaee4ad8dd7ff0e4cdd167a676c5258a514L257-R265): Updated the `insertIgnore` method to check whether the database driver is an instance of `SqliteDriver`. If so, it applies the SQLite-specific `OR IGNORE` flag instead of the standard `IGNORE` flag.

### Import addition:

* [`src/Connection.php`](diffhunk://#diff-fdb82797ac69303b7f9b33a9695e1eaee4ad8dd7ff0e4cdd167a676c5258a514R9): Added an import for `Dibi\Drivers\SqliteDriver` to enable the driver check in the `insertIgnore` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for insert operations to better handle conflicts across different database types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->